### PR TITLE
Fix [#31]: Style bleed through

### DIFF
--- a/UI/Renderer/ConsoleRenderer.cs
+++ b/UI/Renderer/ConsoleRenderer.cs
@@ -41,6 +41,7 @@ public class ConsoleRenderer
 
         // The final string representation of the frame to be rendered to the console
         var frame = new StringBuilder();
+        frame.Append(Ansi.Reset); // Ensure we start with a clean slate for styles
 
         for (int y = 0; y < _height; y++)
         {


### PR DESCRIPTION
Looks like the styles bleed through between frames; not components like I initially thought.

In `UI\Renderer\ConsoleRenderer.cs`
https://github.com/Shresht7/PSFuzzySelect/blob/3d54c9598c7e182c99831f0422c9197e714c5402/UI/Renderer/ConsoleRenderer.cs#L38
the `Render()` method resets the internal `_terminalStyle` to `Style.Default` at the start of every frame. Which is great, however, it **does not** send an actual `Ansi.Reset` command to the terminal to reflect the change!

If the previous render cycle ended with a specific style (e.g. `Inverse`), the terminal's hardware state ***remained*** in that style. When the next frame begins, if the first cell to be rendered has `Style.Default`, the renderer's optimization logic sees that `currentCell.Style == _terminalStyle` and skips sending any ANSI codes! Consequently, the terminal renders that "Default" cell using the lingering style from the previous frame.

The fix is super simple, just ensure that we send a `Ansi.Reset` on the start of every frame to sync the internal `_terminalStyle = Style.Default` assumption with the actual terminal.

fixes #31