### PR TITLE
Refactor fuzzy scoring magic numbers into constants

### DIFF
--- a/Core/FuzzyMatcher.cs
+++ b/Core/FuzzyMatcher.cs
@@ -29,13 +29,13 @@ public class FuzzyMatcher
         if (results.Capacity < items.Count)
             results.Capacity = items.Count;
 
-        // No query provided, return all items with their display strings and a default score of 0
+        // No query provided, return all items with their display strings and a default score
         if (string.IsNullOrWhiteSpace(query))
         {
             for (int i = 0; i < items.Count; i++)
             {
                 var item = items[i];
-                results.Add(new MatchResult(item.Item, item.Display, 0, Array.Empty<int>()));
+                results.Add(new MatchResult(item.Item, item.Display, ScoringConstants.DefaultScore, Array.Empty<int>()));
             }
             return; // early exit since we don't need to perform any matching logic when the query is empty
         }
@@ -67,6 +67,7 @@ public class FuzzyMatcher
     /// <param name="existingMatches">The list of existing match results.</param>
     /// <param name="newItems">The list of new items to match against the query.</param>
     /// <param name="query">The search query string.</param>
+    /// <param name="results">The list to store the merged match results.</param>
     /// <returns>A list of MatchResult objects representing the merged match results.</returns>
     public static void MatchIncremental(List<MatchResult> existingMatches, MatchableItem[] newItems, string query, List<MatchResult> results)
     {
@@ -86,7 +87,7 @@ public class FuzzyMatcher
             for (int i = 0; i < newItems.Length; i++)
             {
                 var item = newItems[i];
-                results.Add(new MatchResult(item.Item, item.Display, 0, Array.Empty<int>()));
+                results.Add(new MatchResult(item.Item, item.Display, ScoringConstants.DefaultScore, Array.Empty<int>()));
             }
             return; // early exit since we don't need to perform any matching logic when the query is empty
         }
@@ -179,13 +180,13 @@ public class FuzzyMatcher
             // Bonus for matching at start of text
             if (foundIndex == 0)
             {
-                score += 20;
+                score += ScoringConstants.StartOfTextBonus;
             }
 
             // Bonus for consecutive matches
             if (foundIndex == textIndex && consecutiveMatches > 0)
             {
-                score += 15;
+                score += ScoringConstants.ConsecutiveMatchBonus;
                 consecutiveMatches++;
             }
             else
@@ -196,11 +197,11 @@ public class FuzzyMatcher
             // Bonus for matching at a word boundary
             if (IsWordStart(text, foundIndex))
             {
-                score += 10;
+                score += ScoringConstants.WordBoundaryBonus;
             }
 
             // Base Score (Earlier matches are better)
-            score += Math.Max(0, 100 - foundIndex);
+            score += Math.Max(0, ScoringConstants.BaseScoreMax - foundIndex);
 
             textIndex = foundIndex + 1;
         }

--- a/Core/ScoringConstants.cs
+++ b/Core/ScoringConstants.cs
@@ -1,0 +1,23 @@
+namespace PSFuzzySelect.Core;
+
+/// <summary>
+/// Contains constants used for calculating fuzzy matching scores.
+/// These values determine the weight given to various matching criteria.
+/// </summary>
+public static class ScoringConstants
+{
+    /// <summary>Bonus awarded when a match occurs at the very beginning of the text.</summary>
+    public const int StartOfTextBonus = 20;
+
+    /// <summary>Bonus awarded for each consecutive character match after the first one.</summary>
+    public const int ConsecutiveMatchBonus = 15;
+
+    /// <summary>Bonus awarded when a match occurs at a word boundary (e.g., after a separator or at a camelCase transition).</summary>
+    public const int WordBoundaryBonus = 10;
+
+    /// <summary>The maximum base score awarded for a match. The actual base score decreases as the match position moves further into the text.</summary>
+    public const int BaseScoreMax = 100;
+
+    /// <summary>The default score assigned to items when no query is provided.</summary>
+    public const int DefaultScore = 0;
+}


### PR DESCRIPTION
Replace hard-coded magic numbers in the fuzzy-matching logic with named constants in a new `ScoringConstants` class. This change enhances code readability and maintainability by providing a centralized location for scoring parameters.

Fixes #46