### PR TITLE
Support Initial Query Parameter

### DIFF
--- a/App/FuzzySelector.cs
+++ b/App/FuzzySelector.cs
@@ -133,6 +133,7 @@ public class FuzzySelector : IApplication
 
     public FuzzySelector(
         string prompt,
+        string query,
         List<MatchableItem>? initialItems = null,
         string[]? properties = null,
         bool multiSelect = false,
@@ -147,7 +148,7 @@ public class FuzzySelector : IApplication
         _previewSize = GetPreviewSize(previewSize);
         _previewPosition = previewPosition;
 
-        _input = new(prompt, string.Empty);
+        _input = new(prompt, query);
         _list = new([], multiSelect, item => _selectedItems.Contains(item));
 
         // Initial refresh to populate matches before the first render

--- a/Cmdlet/Select-Fuzzy.cs
+++ b/Cmdlet/Select-Fuzzy.cs
@@ -83,6 +83,12 @@ public sealed class SelectFuzzyCmdlet : PSCmdlet
     public string Prompt { get; set; } = "Search:";
 
     /// <summary>
+    /// The initial search query to populate the search input field when the fuzzy selector UI is launched.
+    /// </summary>
+    [Parameter]
+    public string Query { get; set; } = string.Empty;
+
+    /// <summary>
     /// Indicates whether to show the preview pane. This is implicitly enabled if <see cref="PreviewScript"/> is provided.
     /// </summary>
     [Parameter]
@@ -202,6 +208,7 @@ public sealed class SelectFuzzyCmdlet : PSCmdlet
         // Initialize the fuzzy selector with the provided parameters
         _selector = new FuzzySelector(
             Prompt,
+            Query,
             null,
             Property,
             MultiSelect.IsPresent,

--- a/Docs/Select-Fuzzy.md
+++ b/Docs/Select-Fuzzy.md
@@ -14,8 +14,8 @@ Provides an interactive fuzzy selection interface for PowerShell pipeline object
 
 ```
 Select-Fuzzy [-InputObject <PSObject>] [-MultiSelect] [[-Property] <String[]>] [-Prompt <String>]
- [-ShowPreview] [-PreviewSize <String>] [-PreviewPosition <PreviewPosition>] [-PreviewScript <ScriptBlock>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-Query <String>] [-ShowPreview] [-PreviewSize <String>] [-PreviewPosition <PreviewPosition>]
+ [-PreviewScript <ScriptBlock>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,6 +45,7 @@ Select-Fuzzy [-InputObject <PSObject>] [-MultiSelect] [[-Property] <String[]>] [
 ```powershell
 Get-ChildItem -File | Select-Fuzzy
 ```
+
 Interactively select a file from the current directory.
 
 ### Example 2: Selecting by Property
@@ -52,6 +53,7 @@ Interactively select a file from the current directory.
 ```powershell
 Get-ChildItem -File -Recurse | Select-Fuzzy -Property Name
 ```
+
 Pick a file by its name from a recursive list.
 
 ### Example 3: Multi-select with Processes
@@ -59,6 +61,7 @@ Pick a file by its name from a recursive list.
 ```powershell
 Get-Process | Select-Fuzzy -MultiSelect | Stop-Process
 ```
+
 Select multiple processes and stop them.
 
 ### Example 4: Using the Preview Pane
@@ -66,6 +69,7 @@ Select multiple processes and stop them.
 ```powershell
 Get-ChildItem -File -Recurse | Select-Fuzzy -ShowPreview -PreviewScript { Get-Content $_.FullName }
 ```
+
 Select multiple files with a live content preview in a side pane.
 
 ## PARAMETERS
@@ -198,6 +202,21 @@ Accept wildcard characters: False
 Type: ActionPreference
 Parameter Sets: (All)
 Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The initial search query to populate the search input field when the fuzzy selector UI is launched.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named


### PR DESCRIPTION
Add a `-Query` parameter to the fuzzy selector to allow pre-filling the search input field when the UI is launched. This enhancement improves user experience by enabling users to start with a specific search string.

Fixes #64